### PR TITLE
TrackGroup2 component Remodify and refactoring

### DIFF
--- a/src/app/(main)/search/[searchText]/[searchType]/page.tsx
+++ b/src/app/(main)/search/[searchText]/[searchType]/page.tsx
@@ -37,17 +37,13 @@ export default async function SearchType({ params }: { params: { searchText: str
           <TrackGroup2
             key={data.id}
             idx={index}
-            id={data.id}
-            name={data.name}
-            duration={data.duration}
-            thumbnail={data.album?.thumbnailUrl}
+            data={data}
             idxWidthStyle={isSearchParamsTrack ? 'block w-[4%]' : 'hidden'}
             imgWidthStyle={isSearchParamsTrack ? 'w-[50%]' : 'w-full'}
             albumTitleWidthStyle={isSearchParamsTrack ? 'w-[40%] block' : 'hidden'}
             formatDateStyle="hidden"
             buttonWrapStyle={isSearchParamsTrack ? 'w-[6%]' : ''}
-            artistList={data.artists?.map((d) => d.name).join(', ')}
-            albumTitle={data.album?.name}
+            trackIdArr={[data.id]}
           />
         ))}
       </div>

--- a/src/app/(main)/search/[searchText]/page.tsx
+++ b/src/app/(main)/search/[searchText]/page.tsx
@@ -39,16 +39,12 @@ export default async function SearchResult({ params }: { params: { searchText: s
                 {slicesTracks.map((track) => (
                   <TrackGroup2
                     key={track.id}
-                    id={track.id}
-                    name={track.name}
-                    duration={track.duration}
-                    thumbnail={track.album.thumbnailUrl}
+                    data={track}
                     idxWidthStyle="hidden"
                     imgWidthStyle="w-full"
                     albumTitleWidthStyle="hidden"
                     formatDateStyle="hidden"
-                    artistList={track.artists.map((t) => t.name).join(', ')}
-                    albumTitle={track.album.name}
+                    trackIdArr={[track.id]}
                   />
                 ))}
               </div>

--- a/src/app/(main)/track/[id]/page.tsx
+++ b/src/app/(main)/track/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { fetchSpotifyArtistDetailData, fetchSpotifyTrackDetailData } from '@/app/api/spotify';
-import DetailContent from '@/app/components/DetailContent';
+import TrackDetailContent from '@/app/components/track/TrackDetailContent';
 import TypeEffect from '@/app/components/TypeEffect';
 import { DEFAULT_PICTURE } from '@/app/constants';
 import { timeString } from '@/app/layout-constants';

--- a/src/app/components/album/AlbumDetailContent.tsx
+++ b/src/app/components/album/AlbumDetailContent.tsx
@@ -29,15 +29,13 @@ export default async function AlbumDetailContent({ type, data, albumArtist }: De
             <TrackGroup2
               key={track.id}
               idx={idx}
-              id={track.id}
-              name={track.name}
-              duration={track.duration}
+              data={track}
+              isGroupTrack={true}
               wrapStyle="text-white py-4"
               idxWidthStyle="block w-[4%]"
               imgWidthStyle="w-[90%]"
               albumTitleWidthStyle="hidden"
               trackIdArr={trackIdArr}
-              artistList={track.artists.map((t) => t.name).join(', ')}
               isHiddenThumbnail="hidden"
               formatDateStyle="hidden"
             />

--- a/src/app/components/artist/ArtistDetailContent.tsx
+++ b/src/app/components/artist/ArtistDetailContent.tsx
@@ -42,16 +42,13 @@ export default async function ArtistDetailContent({ artist }: ArtistDetailConten
             <TrackGroup2
               key={topTrack.id}
               idx={idx}
-              id={topTrack.id}
-              name={topTrack.name}
-              duration={topTrack.duration}
-              thumbnail={topTrack.album.thumbnailUrl}
+              data={topTrack}
+              isGroupTrack={true}
               wrapStyle="text-white py-4"
               imgWidthStyle="w-full"
               albumTitleWidthStyle="hidden"
               formatDateStyle="hidden"
               trackIdArr={trackIdArr}
-              artistList={topTrack.artists.map((artist) => artist.name).join(', ')}
             />
           );
         })}

--- a/src/app/components/playlist/PlaylistDetailContent.tsx
+++ b/src/app/components/playlist/PlaylistDetailContent.tsx
@@ -27,18 +27,13 @@ export default async function PlaylistDetailContent({ type, data }: DetailConten
             <TrackGroup2
               key={track.id}
               idx={idx}
-              id={track.id}
-              name={track.name}
-              duration={track.duration}
-              thumbnail={track.album.thumbnailUrl}
+              data={track}
+              isGroupTrack={true}
               wrapStyle="text-white py-4"
               idxWidthStyle="block w-[4%]"
               imgWidthStyle="w-[30%]"
               albumTitleWidthStyle="w-[30%] block"
               trackIdArr={trackIdArr}
-              artistList={track.artists.map((t) => t.name).join(', ')}
-              formatDate={formatDate(track.addedAt)}
-              albumTitle={track.album.name}
             />
           );
         })}

--- a/src/app/types/api-responses/artist.ts
+++ b/src/app/types/api-responses/artist.ts
@@ -1,3 +1,26 @@
+export interface ArtistTopTrack {
+  id: string; // 곡 ID
+  name: string; // 곡명
+  explicit: boolean; // 성인제한
+  discNumber: number; // 디스크 번호
+  trackNumber: number; // 트랙 번호
+  duration: number; // 곡의 재생 시간 (Millisecond)
+  album: {
+    // 앨범 정보
+    id: string; // 앨범 ID
+    name: string; // 앨범명
+    albumType: 'album' | 'single' | 'compilation';
+    totalTracks: number; // 앨범 수록곡 개수
+    thumbnailUrl?: string; // 앨범 이미지 URL
+    releaseDate: string; // 앨범 발매일 (형식: YYYY or YYYY-MM or YYYY-MM-DD, 예: 2024-01)
+  };
+  artists: {
+    // 곡에 참여한 가수 목록
+    id: string; // 가수 ID
+    name: string; // 가수명
+  }[];
+}
+
 export interface ArtistEssential {
   id: string; // 가수 ID
   name: string; // 가수명

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
       "@/*": ["./src/*"],
     },
     "types": ["youtube"],
+    "target": "es2015",
+    "downlevelIteration": true,
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"],


### PR DESCRIPTION
TrackGroup2 component는 하나를 재활용 하되, 필요한 데이터들을 최대한 props를 통하여 전달 받도록 하여 결합도를 낮춥니다.
- 저번 PR에서 수정한 부분들을 조금 더 심도 깊게 고민하여 재수정 하였습니다.

1. data의 경우, 모두 상당히 흡사한 구조를 지니고 있기 때문에 props를 통하여 받기로 결정하였습니다.
이에 따라 name, duration, thumbnail, artistList 역시 props로 값을 전달받는 것이 아닌,
TrackGroup2 component 내부에서 값을 받아낼 수 있도록 코드를 수정하였습니다.(값을 얻는 방식이 동일)